### PR TITLE
Format dates with the international date format

### DIFF
--- a/src/utils/StargazerStats.js
+++ b/src/utils/StargazerStats.js
@@ -1,5 +1,3 @@
-const months = ["JAN", "FEB", "MAR","APR", "MAY", "JUN", "JUL", "AUG", "SEP", "OCT", "NOV", "DEC"]
-
 class StargazerStats {
 
   calcStats(stargazerData) {
@@ -42,12 +40,8 @@ class StargazerStats {
       'Average days per star': (numOfDays / stargazerData.length).toFixed(3),
       'Days with stars': numOfDays - daysWithoutStars,
       'Max stars in one day': maxStarsPerDay,
-      'Day with most stars': this._formatDate(dayWithMostStars)
+      'Day with most stars': dayWithMostStars.toISOString().slice(0, 10)
     }
-  }
-
-  _formatDate(date) {
-    return date.getDate() + "-" + months[date.getMonth()] + "-" + date.getFullYear()
   }
 }
 


### PR DESCRIPTION
Since StarTrack-js is an international project, I think it should also use the international date format as described in ISO8601. Also makes it easier to see in which year and month the day was, which is probably what most people want to know anyways.

<img width="322" alt="Screen Shot 2020-02-01 at 14 12 10Z" src="https://user-images.githubusercontent.com/36796532/73593485-e99c3f80-44fc-11ea-92da-7f1e5ab68b0e.png">
