### PR TITLE
Add option to display in log scale

### DIFF
--- a/src/components/ChartContainer.js
+++ b/src/components/ChartContainer.js
@@ -1,13 +1,18 @@
 import React from 'react'
 import { Container } from 'react-bootstrap/'
 import ReactApexChart from 'react-apexcharts'
+import { icon } from '@fortawesome/fontawesome-svg-core'
+import { faChartLine, faSuperscript } from '@fortawesome/free-solid-svg-icons'
+
+export const LINEAR = 'linear';
+export const LOGSCALE = 'logscale';
 
 const ChartContainer = (props) => {
 
-  const chartSeries = props.repos.map( (repoData) => {
+  const chartSeries = props.repos.map( ({ username, repo, stargazerData }) => {
     return {
-      name: repoData.username + "/" + repoData.repo,
-      data: repoData.stargazerData
+      name: username + "/" + repo,
+      data: stargazerData,
     }
   })
 
@@ -21,11 +26,38 @@ const ChartContainer = (props) => {
     chart: {
       id: "stargazers",
       zoom: {
-        autoScaleYaxis: (props.repos.length > 1 ? false : true), 
+        autoScaleYaxis: (props.repos.length > 1 ? false : true),
       },
       events: {
         zoomed: onZoom
-      }
+      },
+      toolbar: {
+        tools: {
+          customIcons: [
+            {
+              icon: icon(faChartLine).html,
+              index: -7,
+              class: "chart-fa-icon mr-1",
+              title: "Use linear scale",
+              click () {
+                props.onChartTypeChange(LINEAR);
+              }
+            },
+            {
+              icon: icon(faSuperscript).html,
+              index: -6,
+              class: "chart-fa-icon mr-1",
+              title: "Use logarithmic scale",
+              click () {
+                props.onChartTypeChange(LOGSCALE);
+              }
+            },
+          ],
+        },
+      },
+    },
+    yaxis: {
+      logarithmic: props.chartType === LOGSCALE,
     },
     xaxis: {
       type: "datetime"
@@ -36,16 +68,16 @@ const ChartContainer = (props) => {
       },
     },
     colors: props.repos.map( (repoData) => {
-        return repoData.color
-      })
+      return repoData.color
+    }),
   }
 
   return (
     <Container className="mt-5">
-      <ReactApexChart 
-        options={chartOptions} 
-        series={chartSeries} 
-        type="line" 
+      <ReactApexChart
+        options={chartOptions}
+        series={chartSeries}
+        type="line"
       />
     </Container>
   )

--- a/src/components/MainContainer.js
+++ b/src/components/MainContainer.js
@@ -2,7 +2,7 @@ import React, { useState, useRef } from 'react'
 import { Button, Modal, ProgressBar, Container } from 'react-bootstrap/'
 import './MainContainer.css'
 import RepoDetails from './RepoDetails'
-import ChartContainer from './ChartContainer'
+import ChartContainer, { LINEAR } from './ChartContainer'
 import StatsTable from './StatsTable'
 import UrlDisplay from './UrlDisplay'
 import ClosableBadge from '../shared/ClosableBadge'
@@ -25,6 +25,8 @@ const MainContainer = (props) => {
     isLoading: false,
     loadProgress: 0,
   });
+
+  const [chartType, setChartType] = useState(LINEAR);
 
   const onLoadInProgress = (progress) => {
     setLoadingStatus({
@@ -153,7 +155,7 @@ const MainContainer = (props) => {
           )}
         </div>
       </Container>
-      { repos.length > 0 ? <ChartContainer repos={repos} onTimeRangeChange={handleChartTimeRangeChange}/> : null }
+      { repos.length > 0 ? <ChartContainer repos={repos} onTimeRangeChange={handleChartTimeRangeChange} chartType={chartType} onChartTypeChange={setChartType}/> : null }
       { repos.length > 0 ? <Container><StatsTable repos={repos} requestToSyncChartTimeRange={handleRequestToSyncChartTimeRange}/></Container> : null }
       { repos.length > 0 ? <Container><UrlDisplay repos={repos}/></Container> : null }
       <Footer pageEmpty={repos.length === 0}/>


### PR DESCRIPTION
Fixes #15

Adds two icons to the toolbar: linear scale (default) and log scale.

Doesn't save state to the URL as suggested in #6 as I don't need that myself.

In action:

Linear (default)

![image](https://user-images.githubusercontent.com/155787/85187481-0a223600-b2f4-11ea-92f5-27fbb4d28b72.png)

Log scale:

![image](https://user-images.githubusercontent.com/155787/85187494-1f976000-b2f4-11ea-8254-e32328fae128.png)
