### PR TITLE
feat: change focus to repoName with "/"

### DIFF
--- a/src/components/RepoDetails.js
+++ b/src/components/RepoDetails.js
@@ -18,7 +18,12 @@ const RepoDetails = (props) => {
   const handleKeyPress = (target) => {
     if(target.charCode === 13 && !props.loadInProgress){
       onGoClick();
-    } 
+    }
+
+    if (target.charCode === 47) {
+      target.preventDefault();
+      repoName.current.focus();
+    }
   }
 
   const handlePaste = (event) => {


### PR DESCRIPTION
The idea of this small change is to make the writing more "natural";
When typing the username, pressing `/` will put the focus on the next field. 

_This behavior is common for example in components such as those that ask to enter digits separated by dashes._


pd: Very cool project. Thx!

***

Note: `event.charCode` is considered deprecated. I've used it to keep the nomenclature but maybe it's a good idea to change it to `event.key`. Idea for someone to make another PR :)