### PR TITLE
Allow small mismatch between star count and star data

### DIFF
--- a/src/components/MainContainer/MainContainer.test.tsx
+++ b/src/components/MainContainer/MainContainer.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen, act, waitFor } from "@testing-library/react";
-import MainContainer from "./MainContainer";
+import MainContainer, { allowStarCountAndStarDataMismatch } from "./MainContainer";
 import { getLastCallArguments } from "../../utils/test";
 import * as StargazerLoader from "../../utils/StargazerLoader";
 import * as StargazerStats from "../../utils/StargazerStats";
@@ -233,6 +233,20 @@ describe(MainContainer, () => {
       `This repo has too many stars (100K), GitHub API only allows fetching the first ${stargazerData.starCounts.length} stars`,
       "warning",
     );
+  });
+
+  it("small mismatch between star count and star data", async () => {
+    (getRepoStargazerCount as jest.Mock).mockImplementation(() =>
+      Promise.resolve(stargazerData.starCounts.length + allowStarCountAndStarDataMismatch),
+    );
+
+    setupLoadStargazers();
+
+    render(<MainContainer />);
+
+    await act(() => getLastCallArguments(mockRepoDetailsInput)[0].onGoClick(username, repo));
+
+    expect(mockShowAlert).not.toHaveBeenCalled();
   });
 
   it("handle error fetching star count", async () => {

--- a/src/components/MainContainer/MainContainer.tsx
+++ b/src/components/MainContainer/MainContainer.tsx
@@ -20,6 +20,8 @@ type DateRange = {
   max: string;
 };
 
+export const allowStarCountAndStarDataMismatch = 5;
+
 export default function MainContainer() {
   const [loading, setLoading] = React.useState<boolean>(false);
   const [repoInfos, setRepoInfos] = React.useState<Array<RepoInfo>>([]);
@@ -79,7 +81,11 @@ export default function MainContainer() {
 
       newRepoInfo && setRepoInfos([...repoInfos, newRepoInfo]);
 
-      if (newRepoInfo && stargazerCount > newRepoInfo.stargazerData.starCounts.length) {
+      if (
+        newRepoInfo &&
+        stargazerCount - newRepoInfo.stargazerData.starCounts.length >
+          allowStarCountAndStarDataMismatch
+      ) {
         const stargazerCountShort = Intl.NumberFormat("en-US", { notation: "compact" }).format(
           stargazerCount,
         );


### PR DESCRIPTION
Sometimes there is a small mismatch, probably because of eventual consistency in GitHub data. We allow a leeway of 5 stars mismatch