### PR TITLE
Create SECURITY.md to enable the disclosure of security vulnerabilities

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,5 @@
+# Security Policy
+
+Thank you for helping to improve the security of StarTrack. This project is a small front-end application but we nevertheless appreciate your efforts to report any potential security issues.
+
+To report a security issue, please use the GitHub Security Advisory "[Report a Vulnerability](https://github.com/seladb/StarTrack-js/security/advisories/new)" tab.


### PR DESCRIPTION
Adding a SECURITY.md file to a repo enabled the disclose of vulnerabilities via Github's "Security" tab.

Researchers cannot currently submit vulnerabilities outside of a post on Twitter tagging the author.