### PR TITLE
Update Playwright to the latest version and stop using its internal APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ Dev packages:
 - [ESLint](https://eslint.org/), [Prettier](https://prettier.io/) and their plugins for code linting and formatting
 - [CSpell](https://cspell.org/) for spell check
 - [Playwright](https://playwright.dev/) for integration tests
+- [pixelmatch](https://github.com/mapbox/pixelmatch) and [pngjs](https://github.com/arian/pngjs) for comparing images in Playwright tests
 
 To run it locally follow these steps:
 

--- a/package.json
+++ b/package.json
@@ -75,6 +75,8 @@
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^7.0.1",
     "jsdom": "^28.0.0",
+    "pixelmatch": "^7.2.0",
+    "pngjs": "^7.0.0",
     "prettier": "^3.8.1",
     "typescript-eslint": "^8.56.1",
     "vite": "^7.3.2",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.39.2",
-    "@playwright/test": "^1.59.1",
+    "@playwright/test": "^1.61.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@types/css-mediaquery": "^0.1.4",
     "@types/react-plotly.js": "^2.6.3",
@@ -74,9 +74,9 @@
     "eslint-plugin-prettier": "^5.5.5",
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^7.0.1",
-    "typescript-eslint": "^8.56.1",
     "jsdom": "^28.0.0",
     "prettier": "^3.8.1",
+    "typescript-eslint": "^8.56.1",
     "vite": "^7.3.2",
     "vitest": "^4.0.16"
   }

--- a/tests/basic.spec.ts
+++ b/tests/basic.spec.ts
@@ -1,7 +1,6 @@
 // cspell: ignore nsewdrag
 
 import { test, expect } from "./setup";
-import { getComparator } from "playwright-core/lib/utils";
 import {
   localUrl,
   referenceUrl,
@@ -84,9 +83,8 @@ test("Basic Flow", async ({ page }, testDir) => {
   );
   screenshots.push(await getChartScreenshot(page, testDir.outputPath("repo1and2-actual.png")));
 
-  const comparator = getComparator("image/png");
   screenshots.forEach((screenshot, index) => {
-    expect(comparator(expectedScreenshots[index], screenshot)).toBeNull();
+    expect(screenshot).toMatchSnapshot(expectedScreenshots[index]);
   });
 
   const gridStarsCountRepo1 = await getGridStarsCount(1);
@@ -120,7 +118,7 @@ test("Basic Flow", async ({ page }, testDir) => {
     page,
     testDir.outputPath("repo1b-actual.png"),
   );
-  expect(comparator(screenshots[0], screenshotWithRepo1)).toBeNull();
+  expect(screenshots[0]).toMatchSnapshot(screenshotWithRepo1);
 
   // Remove repo1
   await page.getByTestId("CancelIcon").last().click();

--- a/tests/basic.spec.ts
+++ b/tests/basic.spec.ts
@@ -9,6 +9,7 @@ import {
   repo2,
   authenticate,
   getChartScreenshot,
+  compareImages,
 } from "./utils";
 
 test("Basic Flow", async ({ page }, testDir) => {
@@ -23,7 +24,7 @@ test("Basic Flow", async ({ page }, testDir) => {
 
     await authenticate(page);
 
-    const screenshots: Buffer[] = [];
+    const screenshots: string[] = [];
 
     // Get screenshot for repo1
     await page.getByPlaceholder("Username").fill(username);
@@ -50,7 +51,7 @@ test("Basic Flow", async ({ page }, testDir) => {
 
   await authenticate(page);
 
-  const screenshots: Buffer[] = [];
+  const screenshots: string[] = [];
 
   // Get stats for repo1
   await page.getByPlaceholder("Username").fill(username);
@@ -84,7 +85,7 @@ test("Basic Flow", async ({ page }, testDir) => {
   screenshots.push(await getChartScreenshot(page, testDir.outputPath("repo1and2-actual.png")));
 
   screenshots.forEach((screenshot, index) => {
-    expect(screenshot).toMatchSnapshot(expectedScreenshots[index]);
+    expect(compareImages(screenshot, expectedScreenshots[index])).toBe(0);
   });
 
   const gridStarsCountRepo1 = await getGridStarsCount(1);
@@ -118,7 +119,7 @@ test("Basic Flow", async ({ page }, testDir) => {
     page,
     testDir.outputPath("repo1b-actual.png"),
   );
-  expect(screenshots[0]).toMatchSnapshot(screenshotWithRepo1);
+  expect(compareImages(screenshots[0], screenshotWithRepo1)).toBe(0);
 
   // Remove repo1
   await page.getByTestId("CancelIcon").last().click();

--- a/tests/forecast.spec.ts
+++ b/tests/forecast.spec.ts
@@ -1,5 +1,13 @@
 import { test, expect } from "./setup";
-import { localUrl, referenceUrl, username, repo1, authenticate, getChartScreenshot } from "./utils";
+import {
+  localUrl,
+  referenceUrl,
+  username,
+  repo1,
+  authenticate,
+  getChartScreenshot,
+  compareImages,
+} from "./utils";
 
 test("Forecast", async ({ page }, testDir) => {
   const enableForecast = async () => {
@@ -44,7 +52,7 @@ test("Forecast", async ({ page }, testDir) => {
     page.getByRole("button", { name: "6 months forecast based on the last 4 months" }),
   ).toBeVisible();
 
-  expect(screenshot).toMatchSnapshot(expectedScreenshot);
+  expect(compareImages(screenshot, expectedScreenshot)).toBe(0);
 
   // Show forecast properties
   await page.getByRole("button", { name: "6 months forecast based on the last 4 months" }).click();
@@ -64,5 +72,5 @@ test("Forecast", async ({ page }, testDir) => {
     testDir.outputPath("without-forecast-actual.png"),
   );
 
-  expect(screenshot).not.toEqual(screenshotWithoutForecast);
+  expect(compareImages(screenshotWithoutForecast, expectedScreenshot)).not.toBe(0);
 });

--- a/tests/forecast.spec.ts
+++ b/tests/forecast.spec.ts
@@ -1,5 +1,4 @@
 import { test, expect } from "./setup";
-import { getComparator } from "playwright-core/lib/utils";
 import { localUrl, referenceUrl, username, repo1, authenticate, getChartScreenshot } from "./utils";
 
 test("Forecast", async ({ page }, testDir) => {
@@ -45,8 +44,7 @@ test("Forecast", async ({ page }, testDir) => {
     page.getByRole("button", { name: "6 months forecast based on the last 4 months" }),
   ).toBeVisible();
 
-  const comparator = getComparator("image/png");
-  expect(comparator(expectedScreenshot, screenshot)).toBeNull();
+  expect(screenshot).toMatchSnapshot(expectedScreenshot);
 
   // Show forecast properties
   await page.getByRole("button", { name: "6 months forecast based on the last 4 months" }).click();
@@ -66,5 +64,5 @@ test("Forecast", async ({ page }, testDir) => {
     testDir.outputPath("without-forecast-actual.png"),
   );
 
-  expect(comparator(screenshot, screenshotWithoutForecast)).not.toBeNull();
+  expect(screenshot).not.toEqual(screenshotWithoutForecast);
 });

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -1,7 +1,9 @@
 // cspell: ignore pickledb
 
 import { Page } from "@playwright/test";
-import internal from "stream";
+import fs from "fs";
+import { PNG } from "pngjs";
+import pixelmatch from "pixelmatch";
 
 export const localUrl = "http://localhost:3000/StarTrack-js/#/";
 export const referenceUrl = "https://seladb.github.io/StarTrack-js/#/";
@@ -17,20 +19,31 @@ export const authenticate = async (page: Page) => {
   await page.getByRole("button", { name: "Login" }).waitFor({ state: "detached" });
 };
 
-const readableToBuffer = (readable: internal.Readable): Promise<Buffer> => {
-  return new Promise((resolve, reject) => {
-    const chunks: Array<Buffer> = [];
-    readable.on("data", (chunk) => chunks.push(chunk));
-    readable.on("error", reject);
-    readable.on("end", () => resolve(Buffer.concat(chunks)));
-  });
-};
-
 export const getChartScreenshot = async (page: Page, filename: string) => {
   const downloadPromise = page.waitForEvent("download");
   await page.locator(".modebar-btn").first().click();
   const download = await downloadPromise;
   console.log(__dirname);
   await download.saveAs(filename);
-  return await readableToBuffer(await (await downloadPromise).createReadStream());
+  return filename;
+};
+
+export const compareImages = (file1: string, file2: string) => {
+  const img1 = PNG.sync.read(fs.readFileSync(file1));
+  const img2 = PNG.sync.read(fs.readFileSync(file2));
+
+  if (img1.width !== img2.width || img1.height !== img2.height) {
+    throw new Error("Images have different dimensions");
+  }
+
+  const diff = new PNG({
+    width: img1.width,
+    height: img1.height,
+  });
+
+  const numDiffPixels = pixelmatch(img1.data, img2.data, diff.data, img1.width, img1.height, {
+    threshold: 0.1,
+  });
+
+  return numDiffPixels;
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -5280,6 +5280,13 @@ picomatch@^4.0.3:
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-4.0.4.tgz#fd6f5e00a143086e074dffe4c924b8fb293b0589"
   integrity sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==
 
+pixelmatch@^7.2.0:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/pixelmatch/-/pixelmatch-7.2.0.tgz#59f4e6faca733f763756d175e2579ed71369fd72"
+  integrity sha512-xhcb4yHu9sM/G7foGzoLtXYcC0zHEaOXXjRKhGup0fw78Nf2Tkiapv4EQyMzrbcmQPsllAI7DbFY2UT7PlI9Pg==
+  dependencies:
+    pngjs "^7.0.0"
+
 playwright-core@1.61.1:
   version "1.61.1"
   resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.61.1.tgz#3c99841307efbbabc9d724c41a88c914705d15fc"
@@ -5349,6 +5356,11 @@ plotly.js@^3.5.0:
     topojson-client "^3.1.0"
     webgl-context "^2.2.0"
     world-calendars "^1.0.4"
+
+pngjs@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/pngjs/-/pngjs-7.0.0.tgz#a8b7446020ebbc6ac739db6c5415a65d17090e26"
+  integrity sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==
 
 point-in-polygon@^1.1.0:
   version "1.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1419,12 +1419,12 @@
   resolved "https://registry.yarnpkg.com/@pkgr/core/-/core-0.2.9.tgz#d229a7b7f9dac167a156992ef23c7f023653f53b"
   integrity sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==
 
-"@playwright/test@^1.59.1":
-  version "1.59.1"
-  resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.59.1.tgz#5c4d38eac84a61527af466602ae20277685a02d6"
-  integrity sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==
+"@playwright/test@^1.61.1":
+  version "1.61.1"
+  resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.61.1.tgz#48568dc22af7819e55fa5e8e3bc79b7e6a3e6675"
+  integrity sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==
   dependencies:
-    playwright "1.59.1"
+    playwright "1.61.1"
 
 "@plotly/d3-sankey-circular@0.33.1":
   version "0.33.1"
@@ -5280,17 +5280,17 @@ picomatch@^4.0.3:
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-4.0.4.tgz#fd6f5e00a143086e074dffe4c924b8fb293b0589"
   integrity sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==
 
-playwright-core@1.59.1:
-  version "1.59.1"
-  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.59.1.tgz#d8a2b28bcb8f2bd08ef3df93b02ae83c813244b2"
-  integrity sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==
+playwright-core@1.61.1:
+  version "1.61.1"
+  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.61.1.tgz#3c99841307efbbabc9d724c41a88c914705d15fc"
+  integrity sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==
 
-playwright@1.59.1:
-  version "1.59.1"
-  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.59.1.tgz#f7b0ca61637ae25264cec370df671bbe1f368a4a"
-  integrity sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==
+playwright@1.61.1:
+  version "1.61.1"
+  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.61.1.tgz#d8c0c06eb93c28981afc747bace453bdbd5018bc"
+  integrity sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==
   dependencies:
-    playwright-core "1.59.1"
+    playwright-core "1.61.1"
   optionalDependencies:
     fsevents "2.3.2"
 


### PR DESCRIPTION
Mostly stop using the internal `getComparator()` API, and instead compare images with `pixelmatch`